### PR TITLE
Colourize grep

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -68,6 +68,8 @@ if [[ -f /usr/share/dict/words ]]; then
 fi
 
 ## Aliases
+GREP=$(which -a grep | head -n1)
+alias grep="$GREP --color"
 alias cp="/bin/cp -ivr"
 alias rm="/bin/rm -iv"
 alias mv="/bin/mv -iv"


### PR DESCRIPTION
MacOS puts it at `/usr/bin/grep`, coreutils at /bin/grep`